### PR TITLE
16 scroll main only

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,19 +18,20 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-secondary"> <!-- ① 全体背景はベージュ -->
+  <!-- 表示領域を画面に合わせて固定してスクロールを抑制する -->
+  <body class="fixed top-0 bottom-0 left-0 right-0 bg-secondary">
 
     <!-- ② 画面中央にスマホ幅のアプリ本体を置くコンテナ -->
-    <div class="min-h-screen flex flex-col items-center">
+    <div class="flex flex-col items-center">
 
       <!-- ③ アプリ本体（スマホ画面） -->
-      <div class="w-full max-w-md flex flex-col min-h-screen bg-base-200 text-base-content">
+      <div class="w-full max-w-md flex flex-col h-dvh bg-base-200 text-base-content">
 
 
         <!-- ヘッダーはここにpartialで入れる-->
         <%= render "shared/header" %>
 
-        <main class="flex-1 px-4 py-4 pb-28">
+        <main class="flex-1 overflow-y-auto px-4 pb-28">
 
           <!-- フラッシュメッセージはここにpartialで入れる -->
           <% flash.each do |msg_type, msg| %>


### PR DESCRIPTION
## 概要
- メインコンテンツ（ヘッダーとフッターの間）のみスクロールされるように調整しました

## 修正内容
- `app/views/layouts/application.html.erb`
  - 表示領域を画面に合わせて固定してスクロールを抑制
  - メインコンテンツにのみスクロールを指定

## 影響範囲
- 全ての画面

## レビュー観点
- 要件を満たす実装か
- わかりやすいコードで記載しているか

## 補足
- iOSの仕様で画面全体でスクロールしてしまうようです
- ヘッダーは固定されていますが、フッターがまだ動いてしまいます
- これ以上は本リリースに回します
