### PR TITLE
fix:REMIND_INTERVALをMVPリリースレビュー用に修正

### DIFF
--- a/config/initializers/remind_settings.rb
+++ b/config/initializers/remind_settings.rb
@@ -3,5 +3,6 @@
 if Rails.env.development?
   REMIND_INTERVAL = 5.seconds
 else
-  REMIND_INTERVAL = 24.hours
+  ## ⚠️ MVPレビュー用（短縮）_20260104
+  REMIND_INTERVAL = 5.seconds
 end


### PR DESCRIPTION
## 概要
- REMIND_INTERVALをMVPリリースレビュー用に修正

## 修正内容
- config/initializers/remind_settings.rb
  - 本番環境のリマインド間隔を 24時間 → 5秒 に変更

## 影響範囲
- 本番環境の商品リマインド間隔

## レビュー観点

## 補足
- レビュー通過を確認したら24hに戻す
