### PR TITLE
Fix UI components

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,4 +1,8 @@
 @import "tailwindcss";
+
+@theme {
+  --font-sans: "Noto Sans JP", ui-sans-serif, system-ui, sans-serif;
+}
 @plugin "daisyui"{
   themes: ["Holdon"];
 }
@@ -8,9 +12,9 @@
   default: true;
   prefersdark: false;
   color-scheme: "light";
-  --color-base-100: #FAFAF7;
-  --color-base-200: #FAFAF7;
-  --color-base-300: #FAFAF7;
+  --color-base-100: #FAFAF7;   /* カード・入力欄（白系） */
+  --color-base-200: #F0EDE6;   /* アプリ本体の背景（薄いベージュ） */
+  --color-base-300: #E3DDD2;   /* ボーダー・区切り線 */
   --color-base-content: oklch(21% 0.034 264.665);
 
   --color-primary: #A8C3A0;
@@ -37,9 +41,9 @@
   --color-error: #D08A84;
   --color-error-content: #333333;
 
-  --radius-selector: 0.25rem;
-  --radius-field: 0.25rem;
-  --radius-box: 0.25rem;
+  --radius-box: 1.25rem;
+  --radius-field: 0.5rem;
+  --radius-selector: 1rem;
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
   --border: 1px;

--- a/app/javascript/controllers/expand_controller.js
+++ b/app/javascript/controllers/expand_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// テキストの折りたたみ・展開を管理するコントローラー。
+// 接続時にテキストが実際に溢れているかを確認し、溢れていない場合はトグルボタンを非表示にする。
+export default class extends Controller {
+  static targets = ["text", "toggle"]
+
+  connect() {
+    if (this.textTarget.scrollHeight <= this.textTarget.clientHeight) {
+      this.toggleTarget.classList.add("hidden")
+    }
+  }
+
+  expand() {
+    // line-clamp-4 クラスの有無でトグルし、ボタンラベルを切り替える
+    const isCollapsed = this.textTarget.classList.toggle("line-clamp-4")
+    this.toggleTarget.textContent = isCollapsed ? "続きを表示" : "閉じる"
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,6 @@ application.register("remind-interval", RemindIntervalController)
 import CategorySelectorController from "./category_selector_controller"
 application.register("category-selector", CategorySelectorController)
 
+import ExpandController from "./expand_controller"
+application.register("expand", ExpandController)
+

--- a/app/views/judgements/index.html.erb
+++ b/app/views/judgements/index.html.erb
@@ -1,20 +1,34 @@
-<div class="min-h-screen bg-[#efe3b8] px-4 pb-28">
-  <% if @item.present? %>
+<% if @item.present? %>
+<%# 商品カードのスクロールエリア。固定ボタンカードの高さ分だけ余白を追加 %>
+<div class="pb-44">
     <div class="max-w-md mx-auto pt-6" data-controller="flip">
-      <div class="bg-[#d9d9d9] border border-base-300 rounded-2xl shadow-sm p-4 relative block" data-flip-target="front">
+      <div class="bg-base-100 border border-base-300 rounded-2xl shadow-md p-4 pb-14 relative block" data-flip-target="front">
         <% if @item.item_image.attached? %>
           <%= image_tag @item.item_image.variant(:large), class: "w-full h-60 object-cover rounded-xl mb-6" %>
         <% else %>
-          <div class="w-full h-60 bg-[#cfcfcf] rounded-xl flex items-center justify-center text-2xl font-black text-base-content/80 mb-6">
+          <div class="w-full h-60 bg-base-200 rounded-xl flex items-center justify-center text-2xl font-black text-base-content/80 mb-6">
             画像
           </div>
         <% end %>
 
-        <h2 class="text-2xl font-black leading-tight mb-2"><%= @item.name %></h2>
+        <%# 長い商品名は2行で省略して表示 %>
+        <h2 class="text-2xl font-black leading-tight mb-2 line-clamp-2"><%= @item.name %></h2>
         <p class="text-lg font-semibold text-base-content/90 mb-2">¥<%= number_with_delimiter(@item.price) %></p>
 
         <% if @item.memo.present? %>
-          <p class="text-sm text-base-content/70"><%= simple_format(@item.memo) %></p>
+          <%# expand コントローラーで4行折りたたみ＋「続きを表示」トグルを制御 %>
+          <div data-controller="expand">
+            <%#
+              simple_format は <p> タグを生成するため line-clamp と相性が悪い。
+              whitespace-pre-wrap で改行を保持しつつ、単一要素に line-clamp-4 を適用する。
+            %>
+            <p class="text-sm text-base-content/70 whitespace-pre-wrap line-clamp-4"
+               data-expand-target="text"><%= @item.memo %></p>
+            <button type="button"
+                    class="text-xs text-primary mt-1"
+                    data-expand-target="toggle"
+                    data-action="click->expand#expand">続きを表示</button>
+          </div>
         <% end %>
 
         <button type="button" data-action="flip#toggle" class="btn btn-sm btn-outline btn-circle w-10 h-10 border-base-content/40 shadow-sm absolute bottom-3 right-3">
@@ -22,7 +36,7 @@
         </button>
       </div>
 
-      <div class="bg-[#d9d9d9] border border-base-300 rounded-2xl shadow-sm p-4 relative hidden" data-flip-target="back">
+      <div class="bg-base-100 border border-base-300 rounded-2xl shadow-md p-4 pb-14 relative hidden" data-flip-target="back">
         <div class="text-sm font-bold mb-3">理由メモ</div>
         <%= render "items/reason_memo_readonly", reason: @item.reason %>
 
@@ -31,69 +45,95 @@
         </button>
       </div>
     </div>
+</div>
+<% else %>
+  <%# 商品がない場合はスクロールなしで画面を埋めて表示。main が flex-1 で確定高さを持つため min-h-full が解決される %>
+  <div class="min-h-full flex flex-col items-center justify-center text-base-content/60 bg-base-100 border border-base-300 shadow-md rounded-2xl">
+    <div class="text-6xl mb-4">👐</div>
+    <p class="text-lg font-semibold">判断する商品はありません</p>
+  </div>
+<% end %>
 
-    <div class="sticky bottom-20 z-10 mt-4">
-      <div class="max-w-md mx-auto bg-base-100 border border-base-300 rounded-2xl p-4">
-        <div class="flex items-center justify-between">
-          <%= button_to item_judgement_path(@item), method: :patch, params: { judgement: { purchase_status: :skipped }, redirect_to: judgements_path }, class: "w-20 h-20 rounded-full border-2 border-base-content/70 bg-white flex items-center justify-center text-4xl font-black text-[#9dbbd3] shadow-sm" do %>
-            <span aria-hidden="true">✕</span>
-            <span class="sr-only">見送り</span>
-          <% end %>
+<%# フッター上部に固定表示するボタンカード %>
+<% if @item.present? %>
+  <%#
+    再検討フォーム（id="reconsider-form"）。
+    送信ボタンは下のフレックス行に配置し、form属性でこのフォームに紐付ける。
+    セレクトUIも同じ data-controller スコープ内に置くため、
+    Stimulus コントローラーは外側の div に設定する。
+  %>
+  <div data-controller="remind-interval">
+    <%= form_with url: item_judgement_path(@item), method: :patch, id: "reconsider-form" do %>
+      <%= hidden_field_tag "judgement[purchase_status]", :considering %>
+      <%= hidden_field_tag :redirect_to, judgements_path %>
+      <%# Stimulus コントローラーが calculate() で更新する隠しフィールド %>
+      <%= hidden_field_tag "judgement[remind_interval]", Reminder::DEFAULT_REMIND_INTERVAL,
+            data: { "remind-interval-target": "seconds" } %>
+    <% end %>
 
-          <!-- 再検討ボタン：リマインド期間を選択してから再検討できるようフォームに変更 -->
-          <%= form_with url: item_judgement_path(@item), method: :patch,
-                data: { controller: "remind-interval" } do |f| %>
-            <%= hidden_field_tag "judgement[purchase_status]", :considering %>
-            <%= hidden_field_tag :redirect_to, judgements_path %>
+    <div class="fixed bottom-24 left-1/2 -translate-x-1/2 w-full max-w-md px-4 z-40">
+      <div class="bg-base-100 border border-base-300 rounded-2xl p-4">
 
-            <!-- リマインド期間ピッカー（数値 × 単位） -->
-            <div class="flex items-center justify-center gap-2 mb-3">
-              <select
-                class="select select-bordered select-sm"
-                data-remind-interval-target="value"
-                data-action="change->remind-interval#calculate"
-              >
-                <% (1..60).each do |n| %>
-                  <option value="<%= n %>" <%= "selected" if n == 24 %>><%= n %></option>
-                <% end %>
-              </select>
-
-              <select
-                class="select select-bordered select-sm"
-                data-remind-interval-target="unit"
-                data-action="change->remind-interval#calculate"
-              >
-                <option value="minutes">分</option>
-                <option value="hours" selected>時間</option>
-                <option value="days">日</option>
-              </select>
-
-              <%= hidden_field_tag "judgement[remind_interval]", Reminder::DEFAULT_REMIND_INTERVAL,
-                    data: { "remind-interval-target": "seconds" } %>
-            </div>
-
-            <!-- 再検討ボタン -->
-            <%= f.button type: :submit,
-                  class: "w-20 h-20 rounded-full border-2 border-base-content/70 bg-white flex items-center justify-center text-4xl
-          font-black text-[#7bb08a] shadow-sm" do %>
-              <span aria-hidden="true">↻</span>
-              <span class="sr-only">再検討</span>
+        <%# リマインド期間ピッカー（中央寄せ） %>
+        <div class="flex items-center justify-center gap-2 mb-3">
+          <select
+            class="select select-bordered select-sm"
+            data-remind-interval-target="value"
+            data-action="change->remind-interval#calculate"
+          >
+            <% (1..60).each do |n| %>
+              <option value="<%= n %>" <%= "selected" if n == 24 %>><%= n %></option>
             <% end %>
+          </select>
+
+          <select
+            class="select select-bordered select-sm"
+            data-remind-interval-target="unit"
+            data-action="change->remind-interval#calculate"
+          >
+            <option value="minutes">分</option>
+            <option value="hours" selected>時間</option>
+            <option value="days">日</option>
+          </select>
+        </div>
+
+        <%# 3択ボタン行。再検討ボタンは form属性で #reconsider-form に紐付け %>
+        <div class="flex items-center justify-around">
+
+          <%# 見送りボタン %>
+          <%= button_to item_judgement_path(@item), method: :patch,
+                params: { judgement: { purchase_status: :skipped }, redirect_to: judgements_path },
+                class: "w-16 h-16 rounded-full border-2 border-base-content/70 bg-white flex items-center justify-center text-[#9dbbd3] shadow-sm" do %>
+            <span class="sr-only">見送り</span>
+            <%# Heroicons outline: x-mark %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
           <% end %>
 
-          <%= button_to item_judgement_path(@item), method: :patch, params: { judgement: { purchase_status: :purchased }, redirect_to: judgements_path }, class: "w-20 h-20 rounded-full border-2 border-[#c97b7b] bg-white flex items-center justify-center text-4xl font-black text-[#c97b7b] shadow-sm" do %>
-            <span aria-hidden="true">◯</span>
+          <%# 再検討ボタン（form属性で #reconsider-form の送信ボタンとして機能） %>
+          <button type="submit" form="reconsider-form"
+            class="w-16 h-16 rounded-full border-2 border-base-content/70 bg-white flex items-center justify-center text-[#7bb08a] shadow-sm">
+            <span class="sr-only">再検討</span>
+            <%# Heroicons outline: arrow-path %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+            </svg>
+          </button>
+
+          <%# 購入ボタン %>
+          <%= button_to item_judgement_path(@item), method: :patch,
+                params: { judgement: { purchase_status: :purchased }, redirect_to: judgements_path },
+                class: "w-16 h-16 rounded-full border-2 border-[#c97b7b] bg-white flex items-center justify-center text-[#c97b7b] shadow-sm" do %>
             <span class="sr-only">購入</span>
+            <%# Heroicons outline: check-circle %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" />
+            </svg>
           <% end %>
+
         </div>
       </div>
     </div>
-  <% else %>
-    <div class="max-w-md mx-auto pt-10">
-      <div class="h-[70vh] flex flex-col items-center justify-center text-base-content/60 bg-[#d9d9d9] rounded-2xl border border-base-300">
-        <div class="text-6xl mb-4">👐</div>
-        <p class="text-lg font-semibold">判断する商品はありません</p>
-      </div>
-    </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
 
     <%= yield :head %>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
@@ -19,7 +22,8 @@
   </head>
 
   <!-- 表示領域を画面に合わせて固定してスクロールを抑制する -->
-  <body class="fixed top-0 bottom-0 left-0 right-0 bg-secondary">
+  <body class="fixed top-0 bottom-0 left-0 right-0"
+        style="background: linear-gradient(180deg, var(--color-secondary) 0%, color-mix(in oklab, var(--color-base-100) 85%, var(--color-primary) 15%) 100%);">
 
     <!-- ② 画面中央にスマホ幅のアプリ本体を置くコンテナ -->
     <div class="flex flex-col items-center">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,9 +1,9 @@
-<footer class="bg-primary fixed bottom-0 left-1/2 -translate-x-1/2 z-50 w-full max-w-md">
+<footer class="bg-primary/75 backdrop-blur-md border-t border-primary/40 fixed bottom-0 left-1/2 -translate-x-1/2 z-50 w-full max-w-md">
   <div class="px-4 pb-[env(safe-area-inset-bottom)]">
     <nav class="relative grid grid-cols-5 items-center py-6">
 
       <!-- ホーム -->
-      <%= link_to root_path, class: "grid place-items-center text-base-content/70 hover:text-base-content" do %>
+      <%= link_to root_path, class: "grid place-items-center #{current_page?(root_path) ? 'text-primary-content' : 'text-primary-content/50 hover:text-primary-content/80'}" do %>
         <span class="sr-only">ホーム</span>
         <!-- home svg -->
         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">
@@ -12,7 +12,7 @@
       <% end %>
 
       <!-- 購入判断 -->
-      <%= link_to judgements_path, class: "grid place-items-center text-base-content/70 hover:text-base-content" do %>
+      <%= link_to judgements_path, class: "grid place-items-center #{current_page?(judgements_path) ? 'text-primary-content' : 'text-primary-content/50 hover:text-primary-content/80'}" do %>
         <span class="sr-only">購入判断</span>
         <!-- scale svg -->
         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">
@@ -20,10 +20,10 @@
         </svg>
       <% end %>
 
-      <!-- 中央：＋ボタンの“席” -->
+      <!-- 中央：＋ボタンの"席" -->
       <div class="relative grid place-items-center">
         <%= link_to new_item_path,
-          class: "btn btn-circle btn-lg h-16 w-16 absolute -top-8 border bg-base-100 shadow" do %>
+          class: "btn btn-circle btn-lg h-16 w-16 absolute -top-8 border bg-white text-primary shadow" do %>
           <span class="sr-only">商品追加</span>
           <svg xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 16 16">
             <path fill="currentColor" fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14m.75-10.25v2.5h2.5a.75.75 0 0 1 0 1.5h-2.5v2.5a.75.75 0 0 1-1.5 0v-2.5h-2.5a.75.75 0 0 1 0-1.5h2.5v-2.5a.75.75 0 0 1 1.5 0" clip-rule="evenodd"/>
@@ -32,13 +32,13 @@
       </div>
 
       <!-- リスト -->
-      <%= link_to items_path, class: "grid place-items-center text-base-content/70 hover:text-base-content" do %>
+      <%= link_to items_path, class: "grid place-items-center #{current_page?(items_path) ? 'text-primary-content' : 'text-primary-content/50 hover:text-primary-content/80'}" do %>
         <span class="sr-only">リスト</span>
         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 20 20"><!-- Icon from HeroIcons by Refactoring UI Inc - https://github.com/tailwindlabs/heroicons/blob/master/LICENSE --><path fill="currentColor" fill-rule="evenodd" d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75M6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10m0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75M1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1zm0 10.5a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1zm0-5.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1z" clip-rule="evenodd"/></svg>
       <% end %>
 
       <!-- プロフィール -->
-      <%= link_to "#", class: "grid place-items-center text-base-content/70 hover:text-base-content" do %>
+      <%= link_to "#", class: "grid place-items-center text-primary-content/50 hover:text-primary-content/80" do %>
         <span class="sr-only">プロフィール</span>
         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">
           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.982 18.725A7.49 7.49 0 0 0 12 15.75a7.49 7.49 0 0 0-5.982 2.975m11.964 0a9 9 0 1 0-11.963 0m11.962 0A8.97 8.97 0 0 1 12 21a8.97 8.97 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0a3 3 0 0 1 6 0"/>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,9 @@
-<header class="bg-primary sticky top-0 z-50">
+<header class="bg-primary/75 backdrop-blur-md border-b border-primary/40 sticky top-0 z-50">
   <div class="mx-auto w-full max-w-md px-4 py-4">
     <div class="flex items-center justify-between">
 
       <!-- 左：ロゴ -->
-      <%= link_to root_path, class: "text-3xl font-extrabold text-base-content" do %>
+      <%= link_to root_path, class: "text-3xl font-extrabold text-primary-content" do %>
         Holdon
       <% end %>
 
@@ -13,15 +13,15 @@
           <%= button_to "ログアウト",
                 destroy_user_session_path,
                 method: :delete,
-                class: "btn btn-sm btn-outline" %>
+                class: "btn btn-sm btn-outline border-primary-content/60 text-primary-content" %>
         <% else %>
           <%= link_to "サインアップ",
                 new_user_registration_path,
-                class: "btn btn-sm btn-outline" %>
+                class: "btn btn-sm btn-outline border-primary-content/60 text-primary-content" %>
 
           <%= link_to "ログイン",
                 new_user_session_path,
-                class: "btn btn-sm btn-outline" %>
+                class: "btn btn-sm btn-outline border-primary-content/60 text-primary-content" %>
         <% end %>
       </div>
 
@@ -29,11 +29,11 @@
 
     <%# もし挨拶を出すなら、ヘッダー下に小さく置くと崩れない %>
     <% if user_signed_in? && current_user.name.present? %>
-      <p class="mt-2 text-sm text-base-content/70">
+      <p class="mt-2 text-sm text-primary-content/70">
         こんにちは！<%= current_user.name %>さん
       </p>
     <% else %>
-      <p class="mt-2 text-sm text-base-content/70">
+      <p class="mt-2 text-sm text-primary-content/70">
         物欲をコントロールしましょう
       </p>
     <% end %>


### PR DESCRIPTION
## 概要

  ヘッダー・フッター・判定画面を中心に、アプリ全体のビジュアルデザインを刷新する。

  ## 修正内容

  **テーマ・フォント**
  - Noto Sans JP を導入し、日本語フォントを統一
  - `base-200` / `base-300` のカラーをベージュ系に調整（カード・背景・ボーダーの階層を明確化）
  - ボーダー半径を全体的に大きくし、柔らかい印象に変更
  - ボディ背景をグリーン→ベージュのグラデーションに変更

  **ヘッダー・フッター**
  - `bg-primary/75 backdrop-blur-md` でグリーングラスモーフィズムに統一
  - テキスト・アイコンを `text-primary-content` で統一（active: 不透過、inactive: 50%透過）
  - フッターの＋ボタンを `bg-white text-primary` に反転して目立たせる

  **判定画面（judgements/index）**
  - カード背景を `bg-base-100` に変更、シャドウ強化
  - 商品名を `line-clamp-2` で2行省略表示
  - メモを `expand` Stimulusコントローラーで4行折りたたみ＋「続きを表示」トグルに変更
  - 空状態を全画面中央寄せデザインに変更
  - 判定ボタンをフッター直上に `fixed` 固定表示し、テキスト記号 → SVGアイコンに変更
  - 再検討フォームを `form` 属性で分離し、Stimulusコントローラーのスコープを整理

  ## 影響範囲

  - 全ページ共通（ヘッダー・フッター・フォント・テーマカラー）
  - 判定画面（`/judgements`）

  ## レビュー観点

  - ヘッダー・フッターのコントラスト（`text-primary-content` の視認性）
  - 判定ボタンが固定表示でカードと重ならないか
  - `expand` コントローラーのトグル動作