### PR TITLE
Feature/profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,29 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_username
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, success: #後ほど記載します→t('profile.update.success')
+    else
+      flash.now[:error] = #後ほど記載します→t('profile.update.error')
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_username
+    @user = current_user
+  end
+
+  def user_params
+    params.require(:user).permit(:name)
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,9 +10,9 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path, success: #後ほど記載します→t('profile.update.success')
+      redirect_to profile_path, success: # 後ほど記載します→t('profile.update.success')
     else
-      flash.now[:error] = #後ほど記載します→t('profile.update.error')
+      flash.now[:error] = # 後ほど記載します→t('profile.update.error')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :categories, dependent: :destroy
 
+  validates :name, presence: true, length: { maximum: 20 }
+
   def self.basic_action(auth)
     if auth.present?
       prof = User.find_or_initialize_by(provider: auth["provider"], uid: auth["uid"])

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,29 @@
+<div class="p-4 space-y-6">
+
+  <!-- ページタイトル -->
+  <div class="text-lg font-bold">ユーザー名の変更</div>
+
+  <!-- 編集フォームカード -->
+  <div class="card bg-base-100 shadow-sm border">
+    <div class="card-body p-4 space-y-4">
+
+      <%= form_with model: @user, url: profile_path, method: :patch do |f| %>
+        <div class="space-y-2">
+          <div class="text-xs text-base-content/50 font-medium">ユーザー名</div>
+          <%= f.text_field :name,
+                          class: "input input-bordered w-full",
+                          placeholder: "名前を入力してください" %>
+        </div>
+
+        <div class="pt-2">
+          <%= f.submit "保存する", class: "btn btn-primary w-full" %>
+        </div>
+      <% end %>
+
+    </div>
+  </div>
+
+  <!-- キャンセル -->
+  <%= link_to "キャンセル", profile_path, class: "btn btn-ghost w-full" %>
+
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,19 @@
+<div class="p-4 space-y-6">
+
+  <!-- ページタイトル -->
+  <div class="text-lg font-bold">プロフィール</div>
+
+  <!-- ユーザー名カード -->
+  <div class="card bg-base-100 shadow-sm border">
+    <div class="card-body p-4 space-y-1">
+      <div class="text-xs text-base-content/50 font-medium">ユーザー名</div>
+      <div class="text-base font-bold"><%= @user.name %></div>
+    </div>
+  </div>
+
+  <!-- 編集ボタン -->
+  <%= link_to edit_profile_path, class: "btn btn-primary w-full" do %>
+    編集する
+  <% end %>
+
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -38,7 +38,7 @@
       <% end %>
 
       <!-- プロフィール -->
-      <%= link_to "#", class: "grid place-items-center text-primary-content/50 hover:text-primary-content/80" do %>
+      <%= link_to profile_path, class: "grid place-items-center text-primary-content/50 hover:text-primary-content/80" do %>
         <span class="sr-only">プロフィール</span>
         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">
           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.982 18.725A7.49 7.49 0 0 0 12 15.75a7.49 7.49 0 0 0-5.982 2.975m11.964 0a9 9 0 1 0-11.963 0m11.962 0A8.97 8.97 0 0 1 12 21a8.97 8.97 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0a3 3 0 0 1 6 0"/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,8 @@ Rails.application.routes.draw do
 
   # LINEメッセージ通知
   post "/line/webhook", to: "line_webhooks#callback"
+
+  # プロフィール編集画面
+  resource :profile, only: %i[show edit update]
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,4 @@ Rails.application.routes.draw do
 
   # プロフィール編集画面
   resource :profile, only: %i[show edit update]
-
 end

--- a/spec/requests/profiles_update_spec.rb
+++ b/spec/requests/profiles_update_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Profiles update", type: :request do
+  let(:user) { create(:user) }
+
+  describe "未ログイン" do
+    it "PATCH /profile はログイン画面にリダイレクトされ、更新されない" do
+      expect do
+        patch profile_path, params: { user: { name: "変更後" } }
+      end.not_to change { user.reload.name }
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "ログイン済み" do
+    before { sign_in user }
+
+    context "正常系" do
+      it "有効な名前で更新でき、show にリダイレクトされる" do
+        patch profile_path, params: { user: { name: "新しい名前" } }
+
+        expect(user.reload.name).to eq("新しい名前")
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(profile_path)
+      end
+    end
+
+    context "異常系" do
+      it "名前が空だと更新されない" do
+        original_name = user.name
+
+        patch profile_path, params: { user: { name: "" } }
+
+        expect(user.reload.name).to eq(original_name)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).not_to be_redirect
+      end
+
+      it "名前が21文字以上だと更新されない" do
+        original_name = user.name
+
+        patch profile_path, params: { user: { name: "あ" * 21 } }
+
+        expect(user.reload.name).to eq(original_name)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).not_to be_redirect
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- ユーザー名を表示・変更できるプロフィール機能を実装

## 修正内容
- `resource :profile` でルーティングを追加（show / edit / update）
- `ProfilesController` を新規作成し、show / edit / update アクションを実装
- プロフィール表示画面（show）・編集画面（edit）のviewを作成
- フッターのプロフィールアイコンを `profile_path` に紐付け
- User モデルに name のバリデーションを追加（`presence: true`、最大20文字）
- `profiles_update_spec.rb` でリクエストスペックを追加

## 影響範囲
- フッターのプロフィールアイコンの遷移先が変わる
- `User#name` にバリデーションが追加されるため、既存のユーザー作成処理に影響がある場合あり

## レビュー観点
- `before_action :authenticate_user!` の実行順序が正しいか
- Strong Parametersで `name` のみを許可しているか

## 補足
- なし