### PR TITLE
fix: 画像登録時にカメラが起動してしまう不具合の修正

### DIFF
--- a/app/views/items/_item_form.html.erb
+++ b/app/views/items/_item_form.html.erb
@@ -47,7 +47,6 @@
 
             <%= f.file_field :item_image,
               accept: "image/*,image/heic,image/heif,image/heic-sequence,image/heif-sequence",
-              capture: "environment",
               class: "file-input file-input-bordered file-input-xs w-full max-w-xs" %>
           </div>
 


### PR DESCRIPTION
## 概要
- iOSで画像を添付しようとするとカメラが直接起動してしまう不具合を修正

## 修正内容
- `app/views/items/_item_form.html.erb` の `file_field` から `capture:"environment"` 属性を削除
- `capture` 属性が指定されていると iOSはプルダウンを表示せず背面カメラを直接起動する仕様のため、属性を除去することで従来のiOSファイル選択UI（ライブラリ・カメラ等の選択肢）に戻した

## 影響範囲
- 商品登録・編集フォームの画像添付UI（iOS）

## レビュー観点
- iOSで画像添付タップ時にプルダウンが表示されること
- 画像の選択・アップロード自体が引き続き動作すること

## 補足
- `capture: "environment"` はパーシャル切り出し時（コミット 210d54f）に混入したもので、`new.html.erb` 時点では存在しなかった