### PR TITLE
change: LINE通知文面の修正

### DIFF
--- a/app/services/line_notification_service.rb
+++ b/app/services/line_notification_service.rb
@@ -6,7 +6,7 @@ class LineNotificationService
   def call
     return unless @item.user.provider == "line"
 
-    message_text = "まずは一旦テストです。\n商品名：#{@item.name}\nの判断の時間です。\n購入判断はこちらから：(HoldonのURL)"
+    message_text = "📦 Holdonからお知らせ\n\n「#{@item.name}」の判断タイムです！\n\n少し時間が経った今、どう思いますか？\nぜひ確認してみてください👇\n\n▶ 購入判断はこちら：(HoldonのURL)"
 
     push_request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
       to: @item.user.uid,

--- a/app/services/review_line_notification_service.rb
+++ b/app/services/review_line_notification_service.rb
@@ -15,17 +15,16 @@ class ReviewLineNotificationService
     end.join("\n")
 
     message_text = <<~TEXT
-    先週の自分に、問いかけてみましょう。
+      📊 先週の振り返りです
 
-    あなたは先週、#{items.count}件の買い物を熟考しました。
+      あなたは#{items.count}件の買い物を熟考しました。
 
-    #{item_lines}
+      #{item_lines}
 
-    あの時の決断、今の自分はどう感じていますか？
-    少しだけ時間をとって、記録してみましょう。
+      あの時の決断、今の自分はどう感じていますか？
+      少しだけ時間をとって、記録してみましょう。
 
-    ▶ 振り返りはこちら
-    holdon-app.com
+      ▶ 振り返りはこちら：holdon-app.com
     TEXT
 
     push_request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(


### PR DESCRIPTION
## 概要
- LINE通知の文面をより親しみやすい表現に改善した

## 修正内容
- `line_notification_service.rb`：リマインド通知の文面をテスト用の仮文面から本番向けに変更。絵文字・改行を加えて視認性を向上
- `review_line_notification_service.rb`：週次振り返り通知の文面を整理。ヒアドキュメントのインデントを修正し、URLの表記を1行にまとめた

## 影響範囲
- LINE通知の文面のみ。送信ロジック・タイミングへの変更なし

## レビュー観点
- 通知文面に不自然な表現がないか

## 補足
- なし
