### PR TITLE
add: rails-i18nを追加して判定時刻の表示を日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,6 @@ gem "omniauth-rails_csrf_protection"
 
 # lineメッセージ通知のため追加
 gem "line-bot-api"
+
+# distance_of_time_in_words_to_nowの日本語表示のために追加
+gem "rails-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.3)
       actionpack (= 7.2.3)
       activesupport (= 7.2.3)
@@ -488,6 +491,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3)
+  rails-i18n
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver


### PR DESCRIPTION
## 概要
- ホーム画面の「判断予定のアイテム」セクションで、判定時刻までのカウント表示が英語になっていたため、日本語化した

## 修正内容
- `rails-i18n gem` を追加
- これにより `distance_of_time_in_words_to_now` の出力が日本語（例:「3分後に判定予定」）に変わる

## 影響範囲
- ホーム画面の判断予定アイテムの残り時間表示

## レビュー観点
- 日本語で正しく表示されているか

## 補足
- `config.i18n.default_locale = :ja` はすでに設定済みだったが、Rails標準ヘルパーの翻訳には `rails-i18n` が別途必要だった
- コンテナ再起動で反映されることを確認済み
