### PR TITLE
change: LINEメッセージ通知の文面修正

### DIFF
--- a/app/services/line_notification_service.rb
+++ b/app/services/line_notification_service.rb
@@ -6,7 +6,16 @@ class LineNotificationService
   def call
     return unless @item.user.provider == "line"
 
-    message_text = "📦 Holdonからお知らせ\n\n「#{@item.name}」の判断タイムです！\n\n少し時間が経った今、どう思いますか？\nぜひ確認してみてください👇\n\n▶ 購入判断はこちら：(HoldonのURL)"
+    message_text = <<~TEXT
+    📦 Holdonからお知らせ
+
+    「#{@item.name}」の判断タイムです！
+
+    少し時間が経った今、どう思いますか？
+    ぜひ確認してみてください👇
+
+    ▶ 購入判断はこちら：holdon-app.com
+    TEXT
 
     push_request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
       to: @item.user.uid,


### PR DESCRIPTION
## 概要
- 判断時刻の通知文面を修正

## 修正内容
- 商品が判断時刻を迎えたときのLINE通知の文面にURLが入っていなかったので追記した
- 可読性向上のため`app/services/line_notification_service.rb`の文面をヒアドキュメント方式での代入に変更

## 影響範囲
- LINEでの判断時刻通知の文面

## レビュー観点
- 文面の内容・温度感・絵文字の使い方などがコンセプトとマッチしているか
- 判断レビュー通知文面と共通の箇所は同じ文言を使い回せているか

## 補足
- 特になし