### PR TITLE
Add/onboarding

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,10 +1,10 @@
 class PagesController < ApplicationController
-  layout -> { user_signed_in? ? 'application' : 'landing' }, only: [:terms, :privacy]
+  layout -> { user_signed_in? ? "application" : "landing" }, only: [ :terms, :privacy ]
 
   def onboarding
     return redirect_to home_path if user_signed_in?
 
-    render layout: 'landing'
+    render layout: "landing"
   end
 
   def terms

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,12 @@
 class PagesController < ApplicationController
+  layout -> { user_signed_in? ? 'application' : 'landing' }, only: [:terms, :privacy]
+
+  def onboarding
+    return redirect_to home_path if user_signed_in?
+
+    render layout: 'landing'
+  end
+
   def terms
   end
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,7 +1,3 @@
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to omniauth_authorize_path(resource_name, provider), data: { turbo: false } do %>
-      <%= image_tag 'btn_login_base.png' %>
-    <% end %>
+  <%= button_to user_line_omniauth_authorize_path, data: { turbo: false } do %>
+    <%= image_tag 'btn_login_base.png' %>
   <% end %>
-<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,8 @@
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"/>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
   </head>
 
   <!-- 表示領域を画面に合わせて固定してスクロールを抑制する -->

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for(:title) || "Holdon" %></title>
+
+    <!-- OGP -->
+    <meta property="og:title" content="Holdon - 衝動買いを、立ち止まって考える。">
+    <meta property="og:description" content="欲しいものを登録してリマインドを受け取る。時間をおいて冷静に判断する習慣を、Holdonがサポートします。">
+    <meta property="og:url" content="https://holdon-app.com/">
+    <meta property="og:image" content="<%= asset_url('Holdon_OGP.png') %>">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= yield :head %>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"/>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
+  </head>
+
+  <!-- 表示領域を画面に合わせて固定してスクロールを抑制する -->
+  <body class="fixed top-0 bottom-0 left-0 right-0"
+        style="background: linear-gradient(180deg, var(--color-secondary) 0%, color-mix(in oklab, var(--color-base-100) 85%, var(--color-primary) 15%) 100%);">
+
+    <!-- ② 画面中央にスマホ幅のアプリ本体を置くコンテナ -->
+    <div class="flex flex-col items-center">
+
+      <!-- ③ ハンバーガーメニューのdrawerラップ -->
+      <div class="w-full max-w-md drawer drawer-end">
+        <!-- ④ アプリ本体（スマホ画面） -->
+        <input id="hamburger" type="checkbox" class="drawer-toggle" />
+        <div class="flex flex-col h-dvh bg-base-200 text-base-content drawer-content">
+
+
+          <!-- ヘッダーはここにpartialで入れる-->
+          <header class="bg-primary/75 backdrop-blur-md border-b border-primary/40 sticky top-0 z-50">
+            <div class="mx-auto w-full max-w-md px-4 py-4">
+              <div class="flex items-center justify-between">
+
+                <!-- 左：ロゴ -->
+                <%= link_to root_path, class: "text-3xl font-extrabold text-primary-content" do %>
+                  Holdon
+                <% end %>
+
+                  <!-- ハンバーガーメニュー -->
+                  <label for="hamburger" class="btn btn-ghost btn-square text-primary-content">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                  </label>
+              </div>
+              <p class="mt-1 text-xs text-primary-content/70">物欲をコントロールしましょう</p>
+            </div>
+          </header>
+
+
+          <!-- フラッシュメッセージは main の外に flex item として配置 -->
+          <% if flash.any? %>
+            <div class="px-4 pt-2 shrink-0">
+              <% flash.each do |msg_type, msg| %>
+                <% daisy_type =
+                  case msg_type.to_sym
+                  when :notice, :success then "success"
+                  when :alert,  :error   then "error"
+                  when :warning          then "warning"
+                  when :info             then "info"
+                  else "info"
+                  end
+                %>
+                <div class="alert alert-<%= daisy_type %> mb-2">
+                  <%= msg %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+
+          <main class="flex-1 <%= content_for?(:main_class) ? yield(:main_class) : 'overflow-hidden' %>">
+
+            <%= yield %>
+
+          </main>
+
+        </div>
+        <div class="drawer-side z-50">
+          <label for="hamburger" aria-label="close sidebar" class="drawer-overlay"></label>
+          <div class="bg-base-100 min-h-full w-64 flex flex-col">
+
+            <!-- メニューヘッダー -->
+            <div class="px-6 py-5 border-b border-base-200">
+              <p class="text-lg font-bold text-base-content">メニュー</p>
+            </div>
+
+            <!-- ナビゲーション -->
+            <ul class="menu p-4 flex-1 text-base-content">
+              <li>
+                <%= link_to terms_path, class: "py-3 font-medium" do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  利用規約
+                <% end %>
+              </li>
+              <li>
+                <%= link_to privacy_path, class: "py-3 font-medium" do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                  </svg>
+                  プライバシーポリシー
+                <% end %>
+              </li>
+              <li class="mt-2 border-t border-base-200 pt-2">
+                <%= link_to "https://forms.gle/w5Mnf74DzJ86JbjPA",
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      class: "py-3 font-medium text-base-content/70" do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                  </svg>
+                  お問い合わせ
+                <% end %>
+              </li>
+            </ul>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/pages/onboarding.html.erb
+++ b/app/views/pages/onboarding.html.erb
@@ -1,0 +1,139 @@
+<div class="h-full">
+  <div class="swiper w-full h-full">
+    <div class="swiper-wrapper">
+
+      <%# STEP 01 %>
+      <div class="swiper-slide">
+        <div class="h-full flex flex-col px-5 pt-4 pb-16">
+          <div class="flex-1 flex items-center justify-center min-h-0">
+            <div class="w-full h-full rounded-2xl bg-base-100 shadow-sm flex items-center justify-center">
+              <div class="w-16 h-16 rounded-full bg-primary/15 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 10-7.5 0v4.5m11.356-1.993l1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 01-1.12-1.243l1.264-12A1.125 1.125 0 015.513 7.5h12.974c.576 0 1.059.435 1.119 1.007z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div class="mt-4 text-center">
+            <span class="badge badge-primary font-bold tracking-widest text-xs px-3">STEP 01</span>
+            <h3 class="font-bold text-base mt-2 mb-1">「欲しい」を登録する</h3>
+            <p class="text-xs text-base-content/60 leading-relaxed">気になった商品を見つけたらすぐに登録。URL・価格・メモも一緒に残せます。</p>
+          </div>
+        </div>
+      </div>
+
+      <%# STEP 02 %>
+      <div class="swiper-slide">
+        <div class="h-full flex flex-col px-5 pt-4 pb-16">
+          <div class="flex-1 flex items-center justify-center min-h-0">
+            <div class="w-full h-full rounded-2xl bg-base-100 shadow-sm flex items-center justify-center">
+              <div class="w-16 h-16 rounded-full bg-primary/15 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div class="mt-4 text-center">
+            <span class="badge badge-primary font-bold tracking-widest text-xs px-3">STEP 02</span>
+            <h3 class="font-bold text-base mt-2 mb-1">時間をおく</h3>
+            <p class="text-xs text-base-content/60 leading-relaxed">24時間が冷却期間。衝動的な気持ちが落ち着くのを待ちます。リマインドが届いたら判断の時間です。</p>
+          </div>
+        </div>
+      </div>
+
+      <%# STEP 03 %>
+      <div class="swiper-slide">
+        <div class="h-full flex flex-col px-5 pt-4 pb-16">
+          <div class="flex-1 flex items-center justify-center min-h-0">
+            <div class="w-full h-full rounded-2xl bg-base-100 shadow-sm flex items-center justify-center">
+              <div class="w-16 h-16 rounded-full bg-primary/15 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48 48 0 0012 4.5c-2.291 0-4.545.16-6.75.47m13.5 0q1.515.215 3 .52m-3-.52l2.62 10.726c.122.499-.106 1.028-.589 1.202a6 6 0 01-2.031.352 6 6 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202zm-16.5.52q1.485-.305 3-.52m0 0l2.62 10.726c.122.499-.106 1.028-.589 1.202a6 6 0 01-2.031.352 6 6 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div class="mt-4 text-center">
+            <span class="badge badge-primary font-bold tracking-widest text-xs px-3">STEP 03</span>
+            <h3 class="font-bold text-base mt-2 mb-1">冷静に判断する</h3>
+            <p class="text-xs text-base-content/60 leading-relaxed">「購入」「見送り」「再検討」の3択。時間をおいた分、納得感のある選択ができます。</p>
+          </div>
+        </div>
+      </div>
+
+      <%# STEP 04 %>
+      <div class="swiper-slide">
+        <div class="h-full flex flex-col px-5 pt-4 pb-16">
+          <div class="flex-1 flex items-center justify-center min-h-0">
+            <div class="w-full h-full rounded-2xl bg-base-100 shadow-sm flex items-center justify-center">
+              <div class="w-16 h-16 rounded-full bg-primary/15 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div class="mt-4 text-center">
+            <span class="badge badge-primary font-bold tracking-widest text-xs px-3">STEP 04</span>
+            <h3 class="font-bold text-base mt-2 mb-1">振り返る</h3>
+            <p class="text-xs text-base-content/60 leading-relaxed">判断の履歴を振り返り、自分の購買パターンへの理解を深めましょう。</p>
+          </div>
+        </div>
+      </div>
+
+      <%# LINE ログイン %>
+      <div class="swiper-slide">
+        <div class="h-full flex flex-col items-center justify-center px-6 gap-8 pb-16">
+          <div class="text-4xl font-extrabold text-primary tracking-tight">Holdon</div>
+          <div class="text-center">
+            <h3 class="font-bold text-lg mb-2">さっそく始めましょう</h3>
+            <p class="text-sm text-base-content/60">衝動買いを、立ち止まって考える習慣を。</p>
+          </div>
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+
+    </div>
+    <div class="swiper-pagination"></div>
+    <div class="swiper-button-prev"></div>
+    <div class="swiper-button-next"></div>
+  </div>
+</div>
+
+<style>
+  .swiper-pagination-bullet {
+    background: var(--color-base-content);
+    opacity: 0.2;
+  }
+  .swiper-pagination-bullet-active {
+    background: var(--color-primary) !important;
+    opacity: 1 !important;
+  }
+  .swiper-button-prev,
+  .swiper-button-next {
+    --swiper-navigation-size: 16px;
+    width: 28px;
+    height: 28px;
+    color: var(--color-base-content);
+    opacity: 0.4;
+  }
+  .swiper-button-disabled {
+    display: none !important;
+  }
+</style>
+
+<script>
+  new Swiper('.swiper', {
+    loop: false,
+    speed: 500,
+    pagination: {
+      el: '.swiper-pagination',
+      clickable: true,
+    },
+    navigation: {
+      nextEl: '.swiper-button-next',
+      prevEl: '.swiper-button-prev',
+    },
+  });
+</script>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,4 +1,20 @@
+<% content_for :main_class, "overflow-y-auto px-4 pb-6" %>
+
 <div class="py-6 space-y-4">
+  <!-- 戻るボタン ログイン済み：ホーム、未ログイン：オンボーディング -->
+  <%= link_to root_path, class: "btn btn-ghost btn-square" do %>
+    <svg
+      class="h-8 w-8 text-color-neutral-content"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  <% end %>
+
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body space-y-2">
       <h1 class="text-xl font-bold">プライバシーポリシー</h1>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,4 +1,20 @@
+<% content_for :main_class, "overflow-y-auto px-4 pb-6" %>
+
 <div class="py-6 space-y-4">
+  <!-- 戻るボタン ログイン済み：ホーム、未ログイン：オンボーディング -->
+  <%= link_to root_path, class: "btn btn-ghost btn-square" do %>
+    <svg
+      class="h-8 w-8 text-color-neutral-content"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round">
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  <% end %>
+
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body space-y-2">
       <h1 class="text-xl font-bold">利用規約</h1>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <nav class="relative grid grid-cols-5 items-center py-6">
 
       <!-- ホーム -->
-      <%= link_to root_path, class: "grid place-items-center #{current_page?(root_path) ? 'text-primary-content' : 'text-primary-content/50 hover:text-primary-content/80'}" do %>
+      <%= link_to home_path, class: "grid place-items-center #{current_page?(home_path) ? 'text-primary-content' : 'text-primary-content/50 hover:text-primary-content/80'}" do %>
         <span class="sr-only">ホーム</span>
         <!-- home svg -->
         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,6 +13,7 @@
           <%= button_to "ログアウト",
                 destroy_user_session_path,
                 method: :delete,
+                data: { turbo: false },
                 class: "btn btn-sm btn-outline border-primary-content/60 text-primary-content" %>
         <% else %>
           <%= link_to "ログイン",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   },
   skip: [ :registrations, :passwords ]
 
-  root "home#index"
+  root "pages#onboarding"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+
+  get "home" => "home#index"
 
   resources :items do
     resource :judgement, only: %i[update]

--- a/spec/requests/ogp_spec.rb
+++ b/spec/requests/ogp_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 RSpec.describe "OGP", type: :request do
   describe "GET /" do
-    let(:user) { create(:user) }
-
-    before { sign_in user }
-
     it "OGPメタタグが正しく出力される" do
       get root_path
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,6 +1,28 @@
 require "rails_helper"
 
 RSpec.describe "Pages", type: :request do
+  describe "GET /" do
+    context "未ログイン" do
+      it "200 OK で閲覧できる" do
+        get root_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ログイン済み" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "home_path にリダイレクトされる" do
+        get root_path
+
+        expect(response).to redirect_to(home_path)
+      end
+    end
+  end
+
   describe "GET /terms" do
     context "未ログイン" do
       it "200 OK で閲覧できる" do


### PR DESCRIPTION
## 概要
- 未ログインユーザー向けのオンボーディング画面とlandingレイアウトを実装
- 利用規約・プライバシーポリシーページの導線を改善
- ログアウト後のSwiper初期化失敗・フラッシュのレイアウト崩れ・Turboリセットを修正

## 修正内容
- ルートパスを `home#index` から `pages#onboarding` に変更し、未ログイン時はオンボーディング、ログイン済みはホームへリダイレクト
- `landing.html.erb`を新規作成（フッターなし・フラッシュをmain外に配置）
- Swiperを使った5枚のオンボーディングスライドを実装（STEP 01〜04 + LINEログイン）
- 利用規約・プライバシーポリシーにログイン状態に応じたレイアウト切り替えと戻るボタンを追加
- ログアウト時に `data: { turbo: false }` を追加して完全なページリロードを保証
- `application.html.erb` にSwiper CDNを追加してクロスレイアウトナビゲーション時の初期化失敗を修正

## 影響範囲
- 未ログインユーザーの画面全般（オンボーディング・利用規約・プライバシーポリシー）
- ログイン済みユーザーのログアウト動作
- フッターのホームリンク（`root_path` → `home_path`）

## レビュー観点
- オンボーディング → 利用規約 → 戻るボタンの導線が正しく機能しているか
- ログアウト後にオンボーディング画面が正しく表示されるか
- ログアウト後のハンバーガーメニューでエラーが発生しないか

## 補足
- オンボーディング各スライドの中身（コピー・アイコン）は別ブランチで対応予定
- `app/views/devise/shared/_links.html.erb` のLINEログインボタンはomniauth汎用コードからLINE専用の直接パス指定にシンプル化