### PR TITLE
Fix/increase remind interval min

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -57,7 +57,8 @@ class ItemsController < ApplicationController
       @item.reminder.update!(remind_at: @item.created_at + remind_interval.seconds)
       redirect_to items_path, success: t("items.create.success")
     else
-      flash.now[:error] = t("items.create.error")
+      reminder_errors = @item.reminder&.errors&.full_messages || []
+      flash.now[:error] = reminder_errors.any? ? reminder_errors.join("、") : t("items.create.error")
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -36,6 +36,7 @@ class Item < ApplicationRecord
 
   has_one :judgement, dependent: :destroy
   has_one :reminder, dependent: :destroy
+  validates_associated :reminder
   has_one :reason, dependent: :destroy
   has_one :review, dependent: :destroy
 

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,7 +1,8 @@
 class Reminder < ApplicationRecord
   # リマインド間隔の上下限（秒単位）
-  # 下限：1分 / 上限：60日 / デフォルト：24時間
-  REMIND_INTERVAL_MIN = 60          # 1分
+  # 下限：15分 / 上限：60日 / デフォルト：24時間
+  # neonの無料プランのコンピュート時間クォータ超過を防ぐため1分から15分に引き上げ
+  REMIND_INTERVAL_MIN = 900         # 15分
   REMIND_INTERVAL_MAX = 5_184_000   # 60日
   DEFAULT_REMIND_INTERVAL = 86_400  # 24時間
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  activerecord:
+    attributes:
+      reminder:
+        remind_interval: リマインド間隔
+    errors:
+      models:
+        reminder:
+          attributes:
+            remind_interval:
+              greater_than_or_equal_to: は15分以上で設定してください
+              less_than_or_equal_to: は60日以内で設定してください

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :reminder do
     association :item
     remind_at { 1.hour.from_now }
-    remind_interval { 300 }
+    remind_interval { 3600 }
     notified_at { nil }
   end
 end

--- a/spec/requests/items_create_spec.rb
+++ b/spec/requests/items_create_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Items create", type: :request do
     context "異常系" do
       it "name なしでは作成されない" do
         expect do
-          post items_path, params: { item: { name: "", price: 120_000 } }
+          post items_path, params: { item: { name: "", price: 120_000, remind_interval: 3600 } }
         end.not_to change(Item, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -57,7 +57,7 @@ RSpec.describe "Items create", type: :request do
 
       it "price なしでは作成されない" do
         expect do
-          post items_path, params: { item: { name: "iPad", price: nil } }
+          post items_path, params: { item: { name: "iPad", price: nil, remind_interval: 3600 } }
         end.not_to change(Item, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/items_destroy_spec.rb
+++ b/spec/requests/items_destroy_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Items destroy", type: :request do
     context "関連レコード削除（dependent: :destroy）" do
       let!(:item_with_associations) { create(:item, user: user_a) }
       let!(:judgement) { Judgement.create!(item: item_with_associations, purchase_status: :considering) }
-      let!(:reminder) { Reminder.create!(item: item_with_associations, remind_at: 1.day.from_now, remind_interval: 60) }
+      let!(:reminder) { Reminder.create!(item: item_with_associations, remind_at: 1.day.from_now, remind_interval: 3600) }
       let!(:reason) { Reason.create!(item: item_with_associations, purchase_reason: "買う理由") }
 
       it "item を削除すると judgement/reminder/reason も削除される" do

--- a/spec/requests/items_image_spec.rb
+++ b/spec/requests/items_image_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe "Items image attachment", type: :request do
         post items_path, params: {
           item: {
             name: "画像なし商品",
-            price: 8_000
+            price: 8_000,
+            remind_interval: 3600
           }
         }
       end.to change(Item, :count).by(1)

--- a/spec/requests/judgements_spec.rb
+++ b/spec/requests/judgements_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Judgements update", type: :request do
 
   let(:item) { create(:item, user: user) }
   let!(:judgement) { Judgement.create!(item: item, purchase_status: :considering, decided_at: nil) }
-  let!(:reminder) { Reminder.create!(item: item, remind_at: 1.hour.from_now, remind_interval: 60) }
+  let!(:reminder) { Reminder.create!(item: item, remind_at: 1.hour.from_now, remind_interval: 3600) }
 
   let(:other_item) { create(:item, user: other_user) }
   let!(:other_judgement) { Judgement.create!(item: other_item, purchase_status: :considering, decided_at: nil) }
-  let!(:other_reminder) { Reminder.create!(item: other_item, remind_at: 1.hour.from_now, remind_interval: 60) }
+  let!(:other_reminder) { Reminder.create!(item: other_item, remind_at: 1.hour.from_now, remind_interval: 3600) }
 
   describe "未ログイン" do
     it "PATCH /items/:item_id/judgement は拒否される" do


### PR DESCRIPTION
## 概要
- neonの無料プランのコンピュート時間クォータ超過を防ぐため、リマインド間隔の最小値を1分から15分に引き上げる
- あわせて、バリデーション失敗時に原因をユーザーに伝えられていなかった問題を修正する

## 修正内容
- `Reminder::REMIND_INTERVAL_MIN` を `60`（1分）から `900`（15分）に変更
- `Item` モデルに `validates_associated :reminder` を追加し、Reminderのバリデーション失敗がItemの保存を正しく阻止するように修正
- `ItemsController#create` の失敗時フラッシュメッセージを、Reminderの具体的なエラー内容を表示するよう修正
- `config/locales/ja.yml` を新規作成し、`remind_interval` の属性名・エラーメッセージを日本語化

## 影響範囲
- 商品登録時のリマインド間隔バリデーション（最小値の変更）
- 商品登録フォームのエラーメッセージ表示

## レビュー観点
- 10分（600秒）で登録した場合、「リマインド間隔は15分以上で設定してください」と表示されること
- 15分（900秒）で登録した場合、正常に保存されること
- `validates_associated` がない状態ではItemだけ保存されてしまっていたバグが解消されていること

## 補足
- `update` アクションは今回のスコープ外（構造上の別問題あり）
- 既存のRSpecテストに60秒の境界値テストはなく、テスト修正は不要