### PR TITLE
change: ready_for_review スコープを時間制限なしの全件取得に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,26 @@ docs/diary/{日付}_pr{番号}_{ブランチ名}.md
 
 - 各項目は全て箇条書きで記載する
 - `git log` や `git diff main` で変更内容を把握してから作成する
+- 出力はコピペしやすいよう必ず ` ```markdown ``` ` ブロックで囲む
+- ブロック内のファイル名・メソッド名・スコープ名などは `` ` `` で囲む（GitHub上でコードとしてハイライトされるため）
+（出力例）
+## 概要
+- `ready_for_review` スコープの定義を「先週1週間」の時間制限なしに変更し、振り返り待ちアイテムを全件取得するよう修正した
+
+## 修正内容
+- 既存の `ready_for_review`（先週の日付範囲でフィルタリング）を `last_week_reviews` にリネームしてコメントアウト
+- `ready_for_review` を新たに定義し直し、条件を「`purchased` か `skipped`」「`decided_at` が nil でない」「レビューレコードが存在しない」の3つに絞った
+
+## 影響範囲
+- `app/models/item.rb`
+- `HomeController#index` で `ready_for_review` を呼んでいるが、スコープ名は変わらないため変更不要
+
+## レビュー観点
+- 新しい `ready_for_review` の3条件が要件と一致しているか
+- `last_week_reviews` のロジックが壊れていないか（コメントアウトのみで内容に変更なし）
+
+## 補足
+- `last_week_reviews` は将来の週次レビュー機能などで再利用できる可能性があるためコードとして保持
 
 ---
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -47,25 +47,35 @@ class Item < ApplicationRecord
     .where("reminders.remind_at <= ?", Time.current)
   }
 
-  # 判断レビュー対象の絞り込み
+  # 先週の判断レビュー対象の絞り込み、何かに使えそうなので残しておく
+  # scope :last_week_reviews, -> {
+  #   ## last_week_start : 日曜日の00:00
+  #   ## last_week_end   : 土曜日の23:59(日曜の00:00)
+  #   today_jst = Time.current.in_time_zone("Tokyo")
+  #   last_week_end = today_jst.beginning_of_day - today_jst.wday.days
+  #   last_week_start = last_week_end - 7.days
+
+  #   ## ① purchased か skipped の全件
+  #   ## ② 日曜 00:00 ~ 土曜 23:59 の間
+  #   ## ③ 購入判断がされている（異常系への対処、purchased, skipped だが decided_at: nil があり得るかもしれない）
+  #   ## ④ left_outer_join の結果、reviews.id: nil
+
+  #   includes(:judgement)
+  #   .joins(:judgement)
+  #   .left_outer_joins(:review)
+  #   .where(judgements: { purchase_status: [ Judgement.purchase_statuses[:purchased], Judgement.purchase_statuses[:skipped] ] })
+  #   .where("judgements.decided_at >= ?", last_week_start)
+  #   .where("judgements.decided_at < ?", last_week_end)
+  #   .where.not(judgements: { decided_at: nil })
+  #   .where(reviews: { id: nil })
+  # }
+
+  # 未レビューの商品一覧
   scope :ready_for_review, -> {
-    ## last_week_start : 日曜日の00:00
-    ## last_week_end   : 土曜日の23:59(日曜の00:00)
-    today_jst = Time.current.in_time_zone("Tokyo")
-    last_week_end = today_jst.beginning_of_day - today_jst.wday.days
-    last_week_start = last_week_end - 7.days
-
-    ## ① purchased か skipped の全件
-    ## ② 日曜 00:00 ~ 土曜 23:59 の間
-    ## ③ 購入判断がされている（異常系への対処、purchased, skipped だが decided_at: nil があり得るかもしれない）
-    ## ④ left_outer_join の結果、reviews.id: nil
-
     includes(:judgement)
     .joins(:judgement)
     .left_outer_joins(:review)
     .where(judgements: { purchase_status: [ Judgement.purchase_statuses[:purchased], Judgement.purchase_statuses[:skipped] ] })
-    .where("judgements.decided_at >= ?", last_week_start)
-    .where("judgements.decided_at < ?", last_week_end)
     .where.not(judgements: { decided_at: nil })
     .where(reviews: { id: nil })
   }


### PR DESCRIPTION
## 概要
- `ready_for_review` スコープの定義を「先週1週間」の時間制限なしに変更し、振り返り待ちアイテムを全件取得するよう修正した

## 修正内容
- 既存の `ready_for_review`（先週の日付範囲でフィルタリング）を `last_week_reviews` にリネームしてコメントアウト
- `ready_for_review` を新たに定義し直し、条件を「`purchased` か `skipped`」「`decided_at` が nil でない」「レビューレコードが存在しない」の3つに絞った

## 影響範囲
- `app/models/item.rb`
- `HomeController#index` で `ready_for_review` を呼んでいるが、スコープ名は変わらないため変更不要

## レビュー観点
- 新しい `ready_for_review` の3条件が要件と一致しているか
- `last_week_reviews` のロジックが壊れていないか（コメントアウトのみで内容に変更なし）

## 補足
- `last_week_reviews` は将来の週次レビュー機能などで再利用できる可能性があるためコードとして保持